### PR TITLE
Implement setting and getting request ids via X-TS-Request-ID header

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/http/Session.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/http/Session.java
@@ -1,6 +1,7 @@
 package org.pytorch.serve.http;
 
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
 import java.util.UUID;
 
 public class Session {
@@ -23,7 +24,13 @@ public class Session {
             method = "GET";
             protocol = "HTTP/1.1";
         }
-        requestId = UUID.randomUUID().toString();
+
+        HttpHeaders headers = request.headers();
+        if (headers.contains("X-TS-Request-ID")) {
+            requestId = headers.getAsString("X-TS-Request-ID");
+        } else {
+            requestId = UUID.randomUUID().toString();
+        }
         startTime = System.currentTimeMillis();
     }
 

--- a/frontend/server/src/main/java/org/pytorch/serve/util/NettyUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/NettyUtils.java
@@ -38,7 +38,7 @@ public final class NettyUtils {
 
     private static final Logger logger = LoggerFactory.getLogger("ACCESS_LOG");
 
-    private static final String REQUEST_ID = "x-request-id";
+    private static final String REQUEST_ID = "X-TS-Request-ID";
     private static final AttributeKey<Session> SESSION_KEY = AttributeKey.valueOf("session");
     private static final Dimension DIMENSION = new Dimension("Level", "Host");
     private static final Metric REQUESTS_2_XX =


### PR DESCRIPTION
Set and get request ids as arbitrary strings via `X-TS-Request ID` header to enable better tracing of requests.

Caveat: there are no checks in place to ensure request id uniqueness, which may lead to unpredictable behavior w.r.t queuing etc.