### PR TITLE
Create a queue requests count metric

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/grpcimpl/InferenceImpl.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/grpcimpl/InferenceImpl.java
@@ -92,7 +92,6 @@ public class InferenceImpl extends InferenceAPIsServiceImplBase {
                     new InputParameter(entry.getKey(), entry.getValue().toByteArray()));
         }
 
-        MetricAggregator.handleInferenceMetric(modelName, modelVersion);
         Job job =
                 new GRPCJob(
                         responseObserver,
@@ -109,6 +108,8 @@ public class InferenceImpl extends InferenceAPIsServiceImplBase {
                 InternalServerException e = new InternalServerException(responseMessage);
                 sendErrorResponse(
                         responseObserver, Status.INTERNAL, e, "InternalServerException.()");
+            } else {
+                MetricAggregator.handleInferenceMetric(modelName, modelVersion);
             }
         } catch (ModelNotFoundException | ModelVersionNotFoundException e) {
             sendErrorResponse(responseObserver, Status.INTERNAL, e, null);

--- a/frontend/server/src/main/java/org/pytorch/serve/grpcimpl/InferenceImpl.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/grpcimpl/InferenceImpl.java
@@ -109,7 +109,7 @@ public class InferenceImpl extends InferenceAPIsServiceImplBase {
                 sendErrorResponse(
                         responseObserver, Status.INTERNAL, e, "InternalServerException.()");
             } else {
-                MetricAggregator.handleInferenceMetric(modelName, modelVersion);
+                MetricAggregator.handleInferenceMetric(modelName, modelVersion, job.getPriority());
             }
         } catch (ModelNotFoundException | ModelVersionNotFoundException e) {
             sendErrorResponse(responseObserver, Status.INTERNAL, e, null);

--- a/frontend/server/src/main/java/org/pytorch/serve/http/api/rest/InferenceRequestHandler.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/http/api/rest/InferenceRequestHandler.java
@@ -21,7 +21,6 @@ import org.pytorch.serve.http.BadRequestException;
 import org.pytorch.serve.http.HttpRequestHandlerChain;
 import org.pytorch.serve.http.ResourceNotFoundException;
 import org.pytorch.serve.http.StatusResponse;
-import org.pytorch.serve.metrics.api.MetricAggregator;
 import org.pytorch.serve.openapi.OpenApiUtils;
 import org.pytorch.serve.servingsdk.ModelServerEndpoint;
 import org.pytorch.serve.util.ApiUtils;
@@ -254,8 +253,6 @@ public class InferenceRequestHandler extends HttpRequestHandlerChain {
             NettyUtils.sendJsonResponse(ctx, resp);
             return;
         }
-
-        MetricAggregator.handleInferenceMetric(modelName, modelVersion);
         ApiUtils.addRESTInferenceJob(ctx, modelName, modelVersion, input);
     }
 

--- a/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
@@ -14,6 +14,7 @@ import org.pytorch.serve.grpcimpl.ManagementImpl;
 import org.pytorch.serve.http.messages.DescribeModelResponse;
 import org.pytorch.serve.metrics.Dimension;
 import org.pytorch.serve.metrics.Metric;
+import org.pytorch.serve.metrics.api.MetricAggregator;
 import org.pytorch.serve.util.ApiUtils;
 import org.pytorch.serve.util.ConfigManager;
 import org.pytorch.serve.util.GRPCUtils;
@@ -65,6 +66,10 @@ public class GRPCJob extends Job {
                     PredictionResponse.newBuilder().setPrediction(output).build();
             predictionResponseObserver.onNext(reply);
             predictionResponseObserver.onCompleted();
+
+            long inferTime = System.nanoTime() - getBegin();
+            MetricAggregator.handleInferenceMetric(
+                    getModelName(), getModelVersion(), getScheduled() - getBegin(), inferTime);
 
             logger.debug(
                     "Waiting time ns: {}, Backend time ns: {}",

--- a/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/job/GRPCJob.java
@@ -69,7 +69,7 @@ public class GRPCJob extends Job {
 
             long inferTime = System.nanoTime() - getBegin();
             MetricAggregator.handleInferenceMetric(
-                    getModelName(), getModelVersion(), getScheduled() - getBegin(), inferTime);
+                    getModelName(), getModelVersion(), getPriority(), getScheduled() - getBegin(), inferTime);
 
             logger.debug(
                     "Waiting time ns: {}, Backend time ns: {}",

--- a/frontend/server/src/main/java/org/pytorch/serve/job/RestJob.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/job/RestJob.java
@@ -136,12 +136,13 @@ public class RestJob extends Job {
          * by external clients.
          */
         if (ctx != null) {
-            MetricAggregator.handleInferenceMetric(
-                    getModelName(), getModelVersion(), getScheduled() - getBegin(), inferTime);
             NettyUtils.sendHttpResponse(ctx, resp, true);
         } else if (responsePromise != null) {
             responsePromise.complete(body);
         }
+
+        MetricAggregator.handleInferenceMetric(
+                getModelName(), getModelVersion(), getScheduled() - getBegin(), inferTime);
 
         logger.debug(
                 "Waiting time ns: {}, Backend time ns: {}",

--- a/frontend/server/src/main/java/org/pytorch/serve/job/RestJob.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/job/RestJob.java
@@ -142,7 +142,7 @@ public class RestJob extends Job {
         }
 
         MetricAggregator.handleInferenceMetric(
-                getModelName(), getModelVersion(), getScheduled() - getBegin(), inferTime);
+                getModelName(), getModelVersion(), getPriority(), getScheduled() - getBegin(), inferTime);
 
         logger.debug(
                 "Waiting time ns: {}, Backend time ns: {}",

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/api/MetricAggregator.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/api/MetricAggregator.java
@@ -2,32 +2,33 @@ package org.pytorch.serve.metrics.api;
 
 import org.pytorch.serve.metrics.format.prometheous.PrometheusMetricManager;
 import org.pytorch.serve.util.ConfigManager;
+import org.pytorch.serve.util.Priority;
 
 public final class MetricAggregator {
 
     private MetricAggregator() {}
 
     // Is executed upon successful Job insertion in queue
-    public static void handleInferenceMetric(final String modelName, final String modelVersion) {
+    public static void handleInferenceMetric(final String modelName, final String modelVersion, Priority priority) {
         ConfigManager configMgr = ConfigManager.getInstance();
         if (configMgr.isMetricApiEnable()
                 && configMgr.getMetricsFormat().equals(ConfigManager.METRIC_FORMAT_PROMETHEUS)) {
             PrometheusMetricManager metrics = PrometheusMetricManager.getInstance();
             metrics.incInferCount(modelName, modelVersion);
-            metrics.incQueueCount(modelName, modelVersion);
+            metrics.incQueueCount(modelName, modelVersion, priority);
         }
     }
 
     // Is executed upon successful Job completion
     public static void handleInferenceMetric(
-            final String modelName, final String modelVersion, long timeInQueue, long inferTime) {
+            final String modelName, final String modelVersion, Priority priority, long timeInQueue, long inferTime) {
         ConfigManager configMgr = ConfigManager.getInstance();
         if (configMgr.isMetricApiEnable()
                 && configMgr.getMetricsFormat().equals(ConfigManager.METRIC_FORMAT_PROMETHEUS)) {
             PrometheusMetricManager metrics = PrometheusMetricManager.getInstance();
             metrics.incInferLatency(inferTime, modelName, modelVersion);
             metrics.incQueueLatency(timeInQueue, modelName, modelVersion);
-            metrics.decQueueCount(modelName, modelVersion);
+            metrics.decQueueCount(modelName, modelVersion, priority);
         }
     }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/api/MetricAggregator.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/api/MetricAggregator.java
@@ -27,7 +27,7 @@ public final class MetricAggregator {
                 && configMgr.getMetricsFormat().equals(ConfigManager.METRIC_FORMAT_PROMETHEUS)) {
             PrometheusMetricManager metrics = PrometheusMetricManager.getInstance();
             metrics.incInferLatency(inferTime, modelName, modelVersion);
-            metrics.incQueueLatency(timeInQueue, modelName, modelVersion);
+            metrics.incQueueLatency(timeInQueue, modelName, modelVersion, priority);
             metrics.decQueueCount(modelName, modelVersion, priority);
         }
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/api/MetricAggregator.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/api/MetricAggregator.java
@@ -7,14 +7,18 @@ public final class MetricAggregator {
 
     private MetricAggregator() {}
 
+    // Is executed upon successful Job insertion in queue
     public static void handleInferenceMetric(final String modelName, final String modelVersion) {
         ConfigManager configMgr = ConfigManager.getInstance();
         if (configMgr.isMetricApiEnable()
                 && configMgr.getMetricsFormat().equals(ConfigManager.METRIC_FORMAT_PROMETHEUS)) {
-            PrometheusMetricManager.getInstance().incInferCount(modelName, modelVersion);
+            PrometheusMetricManager metrics = PrometheusMetricManager.getInstance();
+            metrics.incInferCount(modelName, modelVersion);
+            metrics.incQueueCount(modelName, modelVersion);
         }
     }
 
+    // Is executed upon successful Job completion
     public static void handleInferenceMetric(
             final String modelName, final String modelVersion, long timeInQueue, long inferTime) {
         ConfigManager configMgr = ConfigManager.getInstance();
@@ -23,6 +27,7 @@ public final class MetricAggregator {
             PrometheusMetricManager metrics = PrometheusMetricManager.getInstance();
             metrics.incInferLatency(inferTime, modelName, modelVersion);
             metrics.incQueueLatency(timeInQueue, modelName, modelVersion);
+            metrics.decQueueCount(modelName, modelVersion);
         }
     }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
@@ -4,8 +4,6 @@ import org.pytorch.serve.util.ConfigManager;
 import org.pytorch.serve.util.Priority;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
-import java.util.Arrays;
-import java.util.List;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -19,24 +17,25 @@ public final class PrometheusMetricManager {
     private final HashMap<Priority, Gauge> queueRequestCounts;
 
     private PrometheusMetricManager() {
-        List<String> metricsLabels = Arrays.asList("uuid", "model_name", "model_version");
+        String[] metricsLabelsNonQueue = {"uuid", "model_name", "model_version"};
         inferRequestCount =
                 Counter.build()
                         .name("ts_inference_requests_total")
-                        .labelNames(metricsLabels.toArray(new String[0]))
+                        .labelNames(metricsLabelsNonQueue)
                         .help("Total number of inference requests.")
                         .register();
         inferLatency =
                 Counter.build()
                         .name("ts_inference_latency_microseconds")
-                        .labelNames(metricsLabels.toArray(new String[0]))
+                        .labelNames(metricsLabelsNonQueue)
                         .help("Cumulative inference duration in microseconds.")
                         .register();
-        metricsLabels.add("priority");
+
+        String[] metricsLabelsQueue = {"uuid", "model_name", "model_version", "priority"};
         queueLatency =
                 Counter.build()
                         .name("ts_queue_latency_microseconds")
-                        .labelNames(metricsLabels.toArray(new String[0]))
+                        .labelNames(metricsLabelsQueue)
                         .help("Cumulative queue duration in microseconds.")
                         .register();
         queueRequestCounts = new HashMap<Priority, Gauge> ();
@@ -44,7 +43,7 @@ public final class PrometheusMetricManager {
                 queueRequestCounts.put(priority, 
                         Gauge.build()
                                 .name("ts_queue_requests_" + priority.toString().toLowerCase() + "_total")
-                                .labelNames(metricsLabels.toArray(new String[0]))
+                                .labelNames(metricsLabelsQueue)
                                 .help("Current queue inference request count.")
                                 .register());
         }

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
@@ -25,19 +25,19 @@ public final class PrometheusMetricManager {
                 Counter.build()
                         .name("ts_inference_latency_microseconds")
                         .labelNames(metricsLabels)
-                        .help("Cumulative inference duration in microseconds")
+                        .help("Cumulative inference duration in microseconds.")
                         .register();
         queueLatency =
                 Counter.build()
                         .name("ts_queue_latency_microseconds")
                         .labelNames(metricsLabels)
-                        .help("Cumulative queue duration in microseconds")
+                        .help("Cumulative queue duration in microseconds.")
                         .register();
         queueRequestCount =
                 Gauge.build()
                         .name("ts_queue_requests_total")
                         .labelNames(metricsLabels)
-                        .help("Current queue inference request count")
+                        .help("Current queue inference request count.")
                         .register();
     }
 

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
@@ -1,8 +1,11 @@
 package org.pytorch.serve.metrics.format.prometheous;
 
+import org.pytorch.serve.util.ConfigManager;
 import org.pytorch.serve.util.Priority;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import java.util.Arrays;
+import java.util.List;
 import java.util.HashMap;
 import java.util.UUID;
 
@@ -10,37 +13,38 @@ public final class PrometheusMetricManager {
 
     private static final PrometheusMetricManager METRIC_MANAGER = new PrometheusMetricManager();
     private static final String METRICS_UUID = UUID.randomUUID().toString();
-    private Counter inferRequestCount;
-    private Counter inferLatency;
-    private Counter queueLatency;
+    private final Counter inferRequestCount;
+    private final Counter inferLatency;
+    private final Counter queueLatency;
     private final HashMap<Priority, Gauge> queueRequestCounts;
 
     private PrometheusMetricManager() {
-        String[] metricsLabels = {"uuid", "model_name", "model_version"};
+        List<String> metricsLabels = Arrays.asList("uuid", "model_name", "model_version");
         inferRequestCount =
                 Counter.build()
                         .name("ts_inference_requests_total")
-                        .labelNames(metricsLabels)
+                        .labelNames(metricsLabels.toArray(new String[0]))
                         .help("Total number of inference requests.")
                         .register();
         inferLatency =
                 Counter.build()
                         .name("ts_inference_latency_microseconds")
-                        .labelNames(metricsLabels)
+                        .labelNames(metricsLabels.toArray(new String[0]))
                         .help("Cumulative inference duration in microseconds.")
                         .register();
+        metricsLabels.add("priority");
         queueLatency =
                 Counter.build()
                         .name("ts_queue_latency_microseconds")
-                        .labelNames(metricsLabels)
+                        .labelNames(metricsLabels.toArray(new String[0]))
                         .help("Cumulative queue duration in microseconds.")
                         .register();
         queueRequestCounts = new HashMap<Priority, Gauge> ();
         for (Priority priority : Priority.values()) { 
                 queueRequestCounts.put(priority, 
                         Gauge.build()
-                                .name("ts_queue_requests_total")
-                                .labelNames(metricsLabels)
+                                .name("ts_queue_requests_" + priority.toString().toLowerCase() + "_total")
+                                .labelNames(metricsLabels.toArray(new String[0]))
                                 .help("Current queue inference request count.")
                                 .register());
         }
@@ -75,8 +79,9 @@ public final class PrometheusMetricManager {
      * @param modelVersion version of the model
      */
     public void incQueueLatency(long queueTime, String modelName, String modelVersion) {
+        int queueSize = ConfigManager.getInstance().getJobQueueSize();
         queueLatency
-                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion))
+                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion), String.valueOf(queueSize))
                 .inc(queueTime / 1000.0);
     }
 
@@ -100,8 +105,9 @@ public final class PrometheusMetricManager {
      * @param modelVersion version of the model
      */
     public void incQueueCount(String modelName, String modelVersion, Priority priority) {
+        int queueSize = ConfigManager.getInstance().getJobQueueSize();
         queueRequestCounts.get(priority)
-                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion))
+                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion), String.valueOf(queueSize))
                 .inc();
     }
 
@@ -112,8 +118,9 @@ public final class PrometheusMetricManager {
      * @param modelVersion version of the model
      */
     public void decQueueCount(String modelName, String modelVersion, Priority priority) {
+        int queueSize = ConfigManager.getInstance().getJobQueueSize();
         queueRequestCounts.get(priority)
-                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion))
+                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion), String.valueOf(queueSize))
                 .dec();
     }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/format/prometheous/PrometheusMetricManager.java
@@ -1,6 +1,7 @@
 package org.pytorch.serve.metrics.format.prometheous;
 
 import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 import java.util.UUID;
 
 public final class PrometheusMetricManager {
@@ -10,6 +11,7 @@ public final class PrometheusMetricManager {
     private Counter inferRequestCount;
     private Counter inferLatency;
     private Counter queueLatency;
+    private Gauge queueRequestCount;
 
     private PrometheusMetricManager() {
         String[] metricsLabels = {"uuid", "model_name", "model_version"};
@@ -30,6 +32,12 @@ public final class PrometheusMetricManager {
                         .name("ts_queue_latency_microseconds")
                         .labelNames(metricsLabels)
                         .help("Cumulative queue duration in microseconds")
+                        .register();
+        queueRequestCount =
+                Gauge.build()
+                        .name("ts_queue_requests_total")
+                        .labelNames(metricsLabels)
+                        .help("Current queue inference request count")
                         .register();
     }
 
@@ -77,5 +85,30 @@ public final class PrometheusMetricManager {
         inferRequestCount
                 .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion))
                 .inc();
+    }
+
+
+    /**
+     * Counts a valid inference request that has been added to a queue
+     *
+     * @param modelName name of the model
+     * @param modelVersion version of the model
+     */
+    public void incQueueCount(String modelName, String modelVersion) {
+        queueRequestCount
+                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion))
+                .inc();
+    }
+
+    /**
+     * Counts a valid inference request that has been removed from a queue
+     *
+     * @param modelName name of the model
+     * @param modelVersion version of the model
+     */
+    public void decQueueCount(String modelName, String modelVersion) {
+        queueRequestCount
+                .labels(METRICS_UUID, modelName, getOrDefaultModelVersion(modelVersion))
+                .dec();
     }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
@@ -399,7 +399,7 @@ public final class ApiUtils {
             String responseMessage = getInferenceErrorResponseMessage(modelName, version, priority);
             throw new ServiceUnavailableException(responseMessage);
         } else {
-            MetricAggregator.handleInferenceMetric(modelName, version);
+            MetricAggregator.handleInferenceMetric(modelName, version, job.getPriority());
         }
         return job;
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ApiUtils.java
@@ -30,6 +30,7 @@ import org.pytorch.serve.http.messages.ListModelsResponse;
 import org.pytorch.serve.http.messages.RegisterModelRequest;
 import org.pytorch.serve.job.RestJob;
 import org.pytorch.serve.snapshot.SnapshotManager;
+import org.pytorch.serve.metrics.api.MetricAggregator;
 import org.pytorch.serve.util.messages.RequestInput;
 import org.pytorch.serve.util.messages.WorkerCommands;
 import org.pytorch.serve.wlm.Model;
@@ -397,6 +398,8 @@ public final class ApiUtils {
             int priority = job.getPriority();
             String responseMessage = getInferenceErrorResponseMessage(modelName, version, priority);
             throw new ServiceUnavailableException(responseMessage);
+        } else {
+            MetricAggregator.handleInferenceMetric(modelName, version);
         }
         return job;
     }


### PR DESCRIPTION
Implement a metric gauge that shows the current number of requests in each priority's queue and is queryable via the metrics API endpoint. It includes as labels the queue size and priority.

Metrics API outputs for each model and version look like this:
```
# HELP ts_queue_requests_total Current queue inference request count.
# TYPE ts_queue_requests_total gauge
ts_queue_requests_total{uuid="fe9dfb77-102d-4119-8ea1-2a3ed429598a",model_name="model-multi-all2de",model_version="default",priority="HIGH",max_queue_size="100",} 1.0
ts_queue_requests_total{uuid="fe9dfb77-102d-4119-8ea1-2a3ed429598a",model_name="model-multi-all2de",model_version="default",priority="MAX",max_queue_size="100",} 0.0
ts_queue_requests_total{uuid="fe9dfb77-102d-4119-8ea1-2a3ed429598a",model_name="model-multi-all2de",model_version="default",priority="LOW",max_queue_size="100",} 0.0
```