### PR TITLE
Implement GPU distribution logic

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
@@ -86,8 +86,8 @@ public class ModelServer {
             ConfigManager.init(arguments);
             ConfigManager configManager = ConfigManager.getInstance();
             PluginsManager.getInstance().initialize();
+            GPUManager.init(configManager.getNumberOfGpu());
             GPUManager gpuManager = GPUManager.getInstance();
-            gpuManager.init(configManager.getNumberOfGpu());
             InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
             ModelServer modelServer = new ModelServer(configManager, gpuManager);
 

--- a/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
@@ -48,6 +48,7 @@ import org.pytorch.serve.snapshot.SnapshotManager;
 import org.pytorch.serve.util.ConfigManager;
 import org.pytorch.serve.util.Connector;
 import org.pytorch.serve.util.ConnectorType;
+import org.pytorch.serve.util.GPUManager;
 import org.pytorch.serve.util.ServerGroups;
 import org.pytorch.serve.wlm.Model;
 import org.pytorch.serve.wlm.ModelManager;
@@ -66,11 +67,13 @@ public class ModelServer {
     private List<ChannelFuture> futures = new ArrayList<>(2);
     private AtomicBoolean stopped = new AtomicBoolean(false);
     private ConfigManager configManager;
+    private GPUManager gpuManager;
     public static final int MAX_RCVBUF_SIZE = 4096;
 
     /** Creates a new {@code ModelServer} instance. */
-    public ModelServer(ConfigManager configManager) {
+    public ModelServer(ConfigManager configManager, GPUManager gpuManager) {
         this.configManager = configManager;
+        this.gpuManager = gpuManager;
         serverGroups = new ServerGroups(configManager);
     }
 
@@ -83,8 +86,10 @@ public class ModelServer {
             ConfigManager.init(arguments);
             ConfigManager configManager = ConfigManager.getInstance();
             PluginsManager.getInstance().initialize();
+            GPUManager gpuManager = GPUManager.getInstance();
+            gpuManager.init(configManager.getNumberOfGpu());
             InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
-            ModelServer modelServer = new ModelServer(configManager);
+            ModelServer modelServer = new ModelServer(configManager, gpuManager);
 
             Runtime.getRuntime()
                     .addShutdownHook(
@@ -141,7 +146,7 @@ public class ModelServer {
     }
 
     private void initModelStore() throws InvalidSnapshotException, IOException {
-        WorkLoadManager wlm = new WorkLoadManager(configManager, serverGroups.getBackendGroup());
+        WorkLoadManager wlm = new WorkLoadManager(configManager, gpuManager, serverGroups.getBackendGroup());
         ModelManager.init(configManager, wlm);
         WorkflowManager.init(configManager);
         SnapshotManager.init(configManager);

--- a/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/ModelServer.java
@@ -86,7 +86,7 @@ public class ModelServer {
             ConfigManager.init(arguments);
             ConfigManager configManager = ConfigManager.getInstance();
             PluginsManager.getInstance().initialize();
-            GPUManager.init(configManager.getNumberOfGpu());
+            GPUManager.init(configManager);
             GPUManager gpuManager = GPUManager.getInstance();
             InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
             ModelServer modelServer = new ModelServer(configManager, gpuManager);

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -66,6 +66,8 @@ public final class ConfigManager {
     private static final String TS_JOB_QUEUE_SIZE = "job_queue_size";
     private static final String TS_NUMBER_OF_PRIORITIES = "n_priorities";
     private static final String TS_NUMBER_OF_GPU = "number_of_gpu";
+    private static final String TS_MIN_FREE_GPU_MEMORY = "min_free_gpu_memory";
+    private static final String TS_MAX_SHARE_GPU_FAILURES = "max_share_gpu_failures";
     private static final String TS_METRICS_CONFIG = "metrics_config";
 
     // IPEX config option that can be set at config.properties
@@ -368,6 +370,14 @@ public final class ConfigManager {
 
     public int getNumberOfGpu() {
         return getIntProperty(TS_NUMBER_OF_GPU, 0);
+    }
+
+    public int getMinFreeGpuMemory() {
+        return getIntProperty(TS_MIN_FREE_GPU_MEMORY, 4096);
+    }
+
+    public float getMaxShareGpuFailures() {
+        return getFloatProperty(TS_MAX_SHARE_GPU_FAILURES, 0.90f);
     }
 
     public String getMetricsConfigPath() {
@@ -683,6 +693,14 @@ public final class ConfigManager {
             return def;
         }
         return Integer.parseInt(value);
+    }
+
+    private float getFloatProperty(String key, float def) {
+        String value = prop.getProperty(key);
+        if (value == null) {
+            return def;
+        }
+        return Float.parseFloat(value);
     }
 
     public int getDefaultResponseTimeout() {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -119,8 +119,7 @@ public final class GPUManager {
                 if (shareFailures < this.maxShareFailures) {
                     eligibleIdFreeMems.put(i, this.freeMemory[i].intValue());
                 } else {
-                    logger.warn("GPU ID " + String.valueOf(i) + " deemed ineligible since it accounts for at least " + 
-                        String.valueOf(this.maxShareFailures) + " of failures");
+                    logger.warn("GPU ID {} deemed ineligible since it accounts for at least {} of failures", i, this.maxShareFailures);
                 }
             }
         }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -72,7 +72,7 @@ public final class GPUManager {
                 return Integer.parseInt(line);
             }
         } catch (Exception e) {
-            logger.error("Exception raised : " + e.toString());
+            logger.error("An exception occurred when querying for free gpu memory", e);
         }
 
         return -1;

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -20,9 +20,9 @@ public final class GPUManager {
 
     private static GPUManager instance;
 
-    private int nGPUs;
-    private int minFreeMemory;
-    private float maxShareFailures;
+    private final int nGPUs;
+    private final int minFreeMemory;
+    private final float maxShareFailures;
     private AtomicInteger[] nFailures;
     private AtomicInteger[] freeMemory;
     private ConcurrentHashMap<String, Integer> workerIds;

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -1,0 +1,46 @@
+package org.pytorch.serve.util;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class GPUManager {
+
+    private static final Logger logger = LoggerFactory.getLogger(GPUManager.class);
+
+    private static GPUManager instance;
+
+    private int nGPUs;
+    private int[] memoryUsage;
+    private int[] nFailures;
+    private AtomicInteger gpuCounter;
+
+    private GPUManager(int nGPUs) {
+        this.nGPUs = nGPUs;
+        if (nGPUs > 0) {
+            this.gpuCounter = new AtomicInteger(0);
+            this.memoryUsage = new int[this.nGPUs];
+            this.nFailures = new int[this.nGPUs];
+        }
+    }
+
+    public static void init(int nGPUs) {
+        instance = new GPUManager(nGPUs);
+    }
+
+    public static GPUManager getInstance() {
+        return instance;
+    }
+
+    public int getGPU(String workerId) {
+        int gpuId = -1;
+        if (this.nGPUs > 0) {
+            gpuId = gpuCounter.accumulateAndGet(this.nGPUs, (prev, maxGpuId) -> ++prev % maxGpuId);
+        }
+        logger.info("Assigning gpuId " + String.valueOf(gpuId) + " to workerId " + workerId);
+        return gpuId;
+    }
+
+}

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -8,7 +8,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.nio.charset.StandardCharsets;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -1,8 +1,12 @@
 package org.pytorch.serve.util;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.nio.charset.StandardCharsets;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -19,14 +23,21 @@ public final class GPUManager {
     private static GPUManager instance;
 
     private int nGPUs;
+    private int minFreeMemory;
+    private float maxShareFailures;
     private AtomicInteger[] nFailures;
     private AtomicInteger[] freeMemory;
     private ConcurrentHashMap<String, Integer> workerIds;
 
     private GPUManager(int nGPUs) {
         this.nGPUs = nGPUs;
-        this.workerIds = new ConcurrentHashMap<String, Integer>();
+
+        // TODO pass these through as parameters
+        this.minFreeMemory = 100;
+        this.maxShareFailures = 0.5f;
+
         if (nGPUs > 0) {
+            this.workerIds = new ConcurrentHashMap<String, Integer> ();
             this.nFailures = new AtomicInteger[this.nGPUs];
             this.freeMemory = new AtomicInteger[this.nGPUs];
             for (int i = 0; i < this.nGPUs; i++) {
@@ -80,9 +91,10 @@ public final class GPUManager {
     }
 
     public int getGPU(String workerId) {
+        int gpuId = -1;
         // return -1 if there are no gpus
         if (this.nGPUs == 0) {
-            return -1;
+            return gpuId;
         }
         // if the worker was previously assigned to a GPU and now requests a new one, it has likely failed
         // increment failure counter for the previously assigned GPU
@@ -93,9 +105,44 @@ public final class GPUManager {
         for (int i = 0; i < this.nGPUs; i++) {
             this.freeMemory[i].set(queryNvidiaSmiFreeMemory(i));
         }
-        // assign GPU id (dummy for now)
-        int gpuId = 0;
-        logger.info("Assigning gpuId " + String.valueOf(gpuId) + " to workerId " + workerId);
+        // get total failures for share calculation
+        int nFailuresSum = 0;
+        for (int i = 0; i < this.nGPUs; i++) {
+            nFailuresSum += this.nFailures[i].intValue();
+        }
+        // get free memory for all eligible GPUs
+        HashMap<Integer, Integer> eligibleIdFreeMems = new HashMap<Integer, Integer> ();
+        for (int i = 0; i < this.nGPUs; i++) {
+            // check that free memory is available and exceeds minimum
+            if (this.freeMemory[i].intValue() > this.minFreeMemory) {
+                // check that share of failures is smaller than maximum
+                float shareFailures = (float) this.nFailures[i].intValue() / (float) nFailuresSum;
+                if (shareFailures < this.maxShareFailures) {
+                    eligibleIdFreeMems.put(i, this.freeMemory[i].intValue());
+                }
+            }
+        }
+        // get sum of eligible id free memory for prob calculation
+        int eligibleIdFreeMemSum = 0;
+        for (Map.Entry<Integer, Integer> entry : eligibleIdFreeMems.entrySet()) {
+            eligibleIdFreeMemSum += entry.getValue();
+        }
+        // store cumulative probabilities in navigable map
+        float cumProb = 0.0f;
+        TreeMap<Float, Integer> cumProbIds = new TreeMap<Float, Integer> ();
+        for (Map.Entry<Integer, Integer> entry : eligibleIdFreeMems.entrySet()) {
+            int i = entry.getKey();
+            int freeMem = entry.getValue();
+            cumProbIds.put(cumProb, i);
+            cumProb += (float) freeMem / (float) eligibleIdFreeMemSum;
+        }
+        // make random selection
+        float randFloat = ThreadLocalRandom.current().nextFloat();
+        gpuId = cumProbIds.ceilingEntry(randFloat).getValue();
+        logger.info("Assigning gpuId " + String.valueOf(gpuId) + 
+                    " with free memory " + String.valueOf(eligibleIdFreeMems.get(gpuId)) + 
+                    " with number of failures " + String.valueOf(this.nFailures[gpuId].intValue()) + 
+                    " to workerId " + workerId);
         return gpuId;
     }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -33,7 +33,7 @@ public final class GPUManager {
         this.maxShareFailures = maxShareFailures;
 
         if (nGPUs > 0) {
-            this.workerIds = new ConcurrentHashMap<String, Integer> ();
+            this.workerIds = new ConcurrentHashMap<> ();
             this.nFailures = new AtomicInteger[this.nGPUs];
             this.freeMemory = new AtomicInteger[this.nGPUs];
             for (int i = 0; i < this.nGPUs; i++) {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -1,7 +1,6 @@
 package org.pytorch.serve.util;
 
 import java.util.Map;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -2,6 +2,7 @@ package org.pytorch.serve.util;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,17 +14,27 @@ public final class GPUManager {
     private static GPUManager instance;
 
     private int nGPUs;
-    private int[] memoryUsage;
-    private int[] nFailures;
-    private AtomicInteger gpuCounter;
+    private AtomicInteger[] nFailures;
+    private AtomicInteger[] memoryUsage;
+    private ConcurrentHashMap<String, Integer> workerIds;
 
     private GPUManager(int nGPUs) {
         this.nGPUs = nGPUs;
+        this.workerIds = new ConcurrentHashMap<String, Integer>();
         if (nGPUs > 0) {
-            this.gpuCounter = new AtomicInteger(0);
-            this.memoryUsage = new int[this.nGPUs];
-            this.nFailures = new int[this.nGPUs];
+            this.nFailures = new AtomicInteger[this.nGPUs];
+            this.memoryUsage = new AtomicInteger[this.nGPUs];
+            for (int i = 0; i < this.nGPUs; i++) {
+                this.nFailures[i] = new AtomicInteger(0);
+                this.memoryUsage[i] = new AtomicInteger(-1);
+            }
         }
+    }
+
+    private int queryNvidiaSmiMemory(int gpuId) {
+        // dummy for now
+        // returns -1 if memory unavailable, else memory in bytes
+        return 100;
     }
 
     public static void init(int nGPUs) {
@@ -35,12 +46,22 @@ public final class GPUManager {
     }
 
     public int getGPU(String workerId) {
-        int gpuId = -1;
-        if (this.nGPUs > 0) {
-            gpuId = gpuCounter.accumulateAndGet(this.nGPUs, (prev, maxGpuId) -> ++prev % maxGpuId);
+        // return -1 if there are no gpus
+        if (this.nGPUs == 0) {
+            return -1;
         }
+        // if the worker was previously assigned to a GPU and now requests a new one, it has likely failed
+        // increment failure counter for the previously assigned GPU
+        if (this.workerIds.containsKey(workerId)) {
+            this.nFailures[this.workerIds.get(workerId)].incrementAndGet();
+        }
+        // get GPU memory usage per GPU
+        for (int i = 0; i < this.nGPUs; i++) {
+            this.memoryUsage[i].set(queryNvidiaSmiMemory(i));
+        }
+        // assign GPU id (dummy for now)
+        int gpuId = 0;
         logger.info("Assigning gpuId " + String.valueOf(gpuId) + " to workerId " + workerId);
         return gpuId;
     }
-
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerThread.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/WorkerThread.java
@@ -27,6 +27,7 @@ import org.pytorch.serve.job.RestJob;
 import org.pytorch.serve.metrics.Dimension;
 import org.pytorch.serve.metrics.Metric;
 import org.pytorch.serve.util.ConfigManager;
+import org.pytorch.serve.util.GPUManager;
 import org.pytorch.serve.util.Connector;
 import org.pytorch.serve.util.codec.ModelRequestEncoder;
 import org.pytorch.serve.util.codec.ModelResponseDecoder;
@@ -57,6 +58,7 @@ public class WorkerThread implements Runnable {
             new ModelRequestEncoder(ConfigManager.getInstance().getPreferDirectBuffer());
 
     private ConfigManager configManager;
+    private GPUManager gpuManager;
     private EventLoopGroup backendEventGroup;
     private int port;
     private Model model;
@@ -142,19 +144,20 @@ public class WorkerThread implements Runnable {
 
     public WorkerThread(
             ConfigManager configManager,
+            GPUManager gpuManager,
             EventLoopGroup backendEventGroup,
             int port,
-            int gpuId,
             Model model,
             BatchAggregator aggregator,
             WorkerStateListener listener) {
         this.workerId = String.valueOf(port); // Unique across all workers.
         this.configManager = configManager;
+        this.gpuManager = gpuManager;
         this.backendEventGroup = backendEventGroup;
         this.port = port;
         this.model = model;
         this.aggregator = aggregator;
-        this.gpuId = gpuId;
+        this.gpuId = gpuManager.getGPU(this.workerId);
         this.listener = listener;
         startTime = System.currentTimeMillis();
         lifeCycle = new WorkerLifeCycle(configManager, model);
@@ -451,6 +454,8 @@ public class WorkerThread implements Runnable {
         if (backoffIdx < BACK_OFF.length - 1) {
             ++backoffIdx;
         }
+
+        this.gpuId = gpuManager.getGPU(this.workerId);
 
         manager.getScheduler()
                 .schedule(() -> manager.submitTask(this), BACK_OFF[backoffIdx], TimeUnit.SECONDS);


### PR DESCRIPTION
Implement a GPU manager to handle logic related to GPU distribution to worker threads, drawing on discussions in [#155](https://github.com/textshuttle/23mt/issues/155).

TODOs:
- [x] Implement `GPUManager` that assigns GPUs to workerthreads
- [x] Implement GPU memory usage readout (via `nvidia-smi`)
- [x] Implement GPU/worker failure tracking (via `workerId`)
- [x] Implement GPU distribution logic as described in [#155](https://github.com/textshuttle/23mt/issues/155#issuecomment-1473584085)
- [x] Pass `GPUManager` parameters through from env vars
- [x] Restrict GPU failure accounting to last n failures with fixed-size queue