### PR TITLE
Ensure uniqueness of request ids even for duplicate request id header values

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/http/Session.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/http/Session.java
@@ -27,7 +27,8 @@ public class Session {
 
         HttpHeaders headers = request.headers();
         if (headers.contains("x-request-id")) {
-            requestId = headers.getAsString("x-request-id");
+            // adopt header value as prefix for internal request id
+            requestId = headers.getAsString("x-request-id") + ":" + UUID.randomUUID().toString();
         } else {
             requestId = UUID.randomUUID().toString();
         }


### PR DESCRIPTION
When multiple requests have the same request id, connections are closed and the behavior is unpredictable. This PR ensures that even if the `x-request-id` header values are duplicates, the internal ids remain unique by adding a randomly generated suffix.

Together with the changes from [#190](https://github.com/textshuttle/23mt/pull/190), the ids would then follow this schema:

`<api request id or document id>#<segment index>:<random request suffix>`