### PR TITLE
Queue Status Metric

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
@@ -48,7 +48,7 @@ public class MetricCollector implements Runnable {
                                     "QueueStatus",
                                     mvStatusString,
                                     "Requests",
-                                    modelName,
+                                    modelName + "/" + versionName,
                                         new Dimension("Level", "Host")));
                 }
             }

--- a/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/metrics/MetricCollector.java
@@ -47,9 +47,9 @@ public class MetricCollector implements Runnable {
                             new Metric(
                                     "QueueStatus",
                                     mvStatusString,
-                                    "jobsInQueue",
+                                    "Requests",
                                     modelName,
-                                        new Dimension("Level", "ModelVersion")));
+                                        new Dimension("Level", "Host")));
                 }
             }
 

--- a/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
@@ -136,6 +136,7 @@ public class PriorityLinkedBlockingDeque<T extends Prioritisable> {
         String response = "";
         for (Priority priority : Priority.values()) {
             int currentQueueStatus = this.priorityDeques.get(priority).size();
+            logger.warn("priority {}, currentQueueStatus {}", priority.toString(), currentQueueStatus);
             response = response + priority.toString() + "=" + String.valueOf(currentQueueStatus) + ",";
         }
         response = response + "queueSize=" + String.valueOf(this.queueSize);

--- a/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
@@ -20,11 +20,13 @@ public class PriorityLinkedBlockingDeque<T extends Prioritisable> {
     final ReentrantLock lock = new ReentrantLock();
     private final Condition notEmpty = lock.newCondition();
 
+    private final int queueSize;
     private final float highPrioProb;
     private final ConcurrentHashMap<Priority, LinkedBlockingDeque<T>> priorityDeques;
 
     public PriorityLinkedBlockingDeque(int queueSize, float highPrioProb) {
 
+        this.queueSize = queueSize;
         this.highPrioProb = highPrioProb;
         this.priorityDeques = new ConcurrentHashMap<Priority, LinkedBlockingDeque<T>>();
 
@@ -136,7 +138,7 @@ public class PriorityLinkedBlockingDeque<T extends Prioritisable> {
             int currentQueueStatus = this.priorityDeques.get(priority).size();
             response = response + priority.toString() + "=" + String.valueOf(currentQueueStatus) + ",";
         }
-        response = response.substring(0, response.length() - 1);
+        response = response.substring(0, response.length() - 1) + "|queueSize=" + String.valueOf(this.queueSize);
         return response;
 
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
@@ -129,4 +129,15 @@ public class PriorityLinkedBlockingDeque<T extends Prioritisable> {
             lock.unlock();
         }
     }
+
+    public String getQueueStatusString() {
+        String response = "";
+        for (Priority priority : Priority.values()) {
+            int currentQueueStatus = this.priorityDeques.get(priority).size();
+            response = response + priority.toString() + "=" + String.valueOf(currentQueueStatus) + ",";
+        }
+        response = response.substring(0, response.length() - 1);
+        return response;
+
+    }
 }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
@@ -136,7 +136,6 @@ public class PriorityLinkedBlockingDeque<T extends Prioritisable> {
         String response = "";
         for (Priority priority : Priority.values()) {
             int currentQueueStatus = this.priorityDeques.get(priority).size();
-            logger.warn("priority {}, currentQueueStatus {}", priority.toString(), currentQueueStatus);
             response = response + priority.toString() + "=" + String.valueOf(currentQueueStatus) + ",";
         }
         response = response + "queueSize=" + String.valueOf(this.queueSize);

--- a/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/PriorityLinkedBlockingDeque.java
@@ -138,7 +138,7 @@ public class PriorityLinkedBlockingDeque<T extends Prioritisable> {
             int currentQueueStatus = this.priorityDeques.get(priority).size();
             response = response + priority.toString() + "=" + String.valueOf(currentQueueStatus) + ",";
         }
-        response = response.substring(0, response.length() - 1) + "|queueSize=" + String.valueOf(this.queueSize);
+        response = response + "queueSize=" + String.valueOf(this.queueSize);
         return response;
 
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/wlm/Model.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/wlm/Model.java
@@ -252,4 +252,8 @@ public class Model {
     public void setResponseTimeout(int responseTimeout) {
         this.responseTimeout = responseTimeout;
     }
+
+    public String getQueueStatusString() {
+        return jobsDb.get(DEFAULT_DATA_QUEUE).getQueueStatusString();
+    }
 }


### PR DESCRIPTION
Implements a queue status metric that is logged along with the `TorchServe`-internal system metrics. Directly logs the current queue size for each priority for each version for each model along with the maximum queue size.

Outputs occur every `metric_time_interval` seconds (pre-existing parameter in `config.properties`) and are formatted like this:
```
2023-03-30T18:41:25,586 [INFO ] pool-3-thread-2 TS_METRICS - QueueStatus.Requests:LOW=2,HIGH=5,MAX=0,queueSize=100|#Level:Host|#hostname:model-doc-multi-all2de/default,timestamp:1680201685
```

Note: it is located in the `MetricsCollector`, which often fails as described in https://github.com/textshuttle/23mt/issues/136. I put the logging after the GPU metrics collection, so I hope it will still be logged despite the failures, but I haven't tested it yet in that scenario.