### PR TITLE
Simplify GPU distribution

### DIFF
--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -381,10 +381,6 @@ public final class ConfigManager {
         return getIntProperty(TS_MIN_FREE_GPU_MEMORY, 4096);
     }
 
-    public float getMaxShareGpuFailures() {
-        return getFloatProperty(TS_MAX_SHARE_GPU_FAILURES, 0.90f);
-    }
-
     public int getOverrideGpuId() {
         return getIntProperty(TS_OVERRIDE_GPU_ID, -1);
     }

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -686,7 +686,9 @@ public final class ConfigManager {
                 + "\nWorkflow Store: "
                 + (getWorkflowStore() == null ? "N/A" : getWorkflowStore())
                 + "\nModel config: "
-                + prop.getProperty(MODEL_CONFIG, "N/A");
+                + prop.getProperty(MODEL_CONFIG, "N/A")
+                + "\nOverride GPU ID: "
+                + getOverrideGpuId();
     }
 
     public boolean useNativeIo() {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/ConfigManager.java
@@ -68,6 +68,7 @@ public final class ConfigManager {
     private static final String TS_NUMBER_OF_GPU = "number_of_gpu";
     private static final String TS_MIN_FREE_GPU_MEMORY = "min_free_gpu_memory";
     private static final String TS_MAX_SHARE_GPU_FAILURES = "max_share_gpu_failures";
+    private static final String TS_OVERRIDE_GPU_ID = "override_gpu_id";
     private static final String TS_METRICS_CONFIG = "metrics_config";
     private static final String TS_METRICS_MODE = "metrics_mode";
     private static final String TS_DISABLE_SYSTEM_METRICS = "disable_system_metrics";
@@ -382,6 +383,10 @@ public final class ConfigManager {
 
     public float getMaxShareGpuFailures() {
         return getFloatProperty(TS_MAX_SHARE_GPU_FAILURES, 0.90f);
+    }
+
+    public int getOverrideGpuId() {
+        return getIntProperty(TS_OVERRIDE_GPU_ID, -1);
     }
 
     public String getMetricsConfigPath() {

--- a/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
+++ b/frontend/server/src/main/java/org/pytorch/serve/util/GPUManager.java
@@ -24,15 +24,17 @@ public final class GPUManager {
 
     private final int nGPUs;
     private final int minFreeMemory;
+    private final int overrideGpuId;
     private final float maxShareFailures;
 
     private AtomicInteger[] freeMemory;
     private HashMap<String, Integer> workerIds;
     private ArrayDeque<Integer> gpuFailureHistory;
 
-    private GPUManager(int nGPUs, int minFreeMemory, float maxShareFailures) {
+    private GPUManager(int nGPUs, int minFreeMemory, int overrideGpuId, float maxShareFailures) {
         this.nGPUs = nGPUs;
         this.minFreeMemory = minFreeMemory;
+        this.overrideGpuId = overrideGpuId;
         this.maxShareFailures = maxShareFailures;
 
         this.gpuFailureHistory = new ArrayDeque<> ();
@@ -84,8 +86,9 @@ public final class GPUManager {
     public static synchronized void init(ConfigManager configManager) {
         int nGPUs = configManager.getNumberOfGpu();
         int minFreeMemory = configManager.getMinFreeGpuMemory();
+        int override_gpu_id = configManager.getOverrideGpuId();
         float maxShareFailures = configManager.getMaxShareGpuFailures();
-        instance = new GPUManager(nGPUs, minFreeMemory, maxShareFailures);
+        instance = new GPUManager(nGPUs, minFreeMemory, override_gpu_id, maxShareFailures);
     }
 
     public static synchronized GPUManager getInstance() {
@@ -95,7 +98,12 @@ public final class GPUManager {
     public synchronized int getGPU(String workerId) {
         // return -1 if there are no gpus
         if (this.nGPUs == 0) {
+            logger.error("No eligible GPUs available, falling back to CPU");
             return -1;
+        }
+        // return override if given
+        if (this.overrideGpuId > -1) {
+            return this.overrideGpuId;
         }
         int failedGpuId;
         // if the worker was previously assigned to a GPU and now requests a new one, it has likely failed


### PR DESCRIPTION
Simplify GPU distribution so it can be controlled better in a multi-`model_server` setup.

Changes:
* Add env var `override_gpu_id` that makes `GPUManager` always assign a specified GPU to new workers. Default value is `-1`, which does not have any effect.
* Remove GPU failure tracking logic since it is not practical
* Stochastic GPU distribution weighted by current free memory distribution remains